### PR TITLE
Create workshop-focused README with visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# SalesDashboard
+# Sales Dashboard Workshop
+
+Welcome to the companion repository for the *Sales Dashboard* workshop delivered as part of the **Software Engineering for Data Science** course. This repository preserves the workshop assets, highlights the learning journey, and provides guidance on how to open and explore the Tableau and Power BI dashboards that were created live with the cohort.
+
+![Sales Dashboard Overview](assets/sales_dashboard_overview.svg)
+
+## Workshop Story
+
+Teaching is one of the fastest ways to solidify technical mastery. During this workshop I had the opportunity to guide 33 students through the complete lifecycle of building a sales analytics experience:
+
+- **Installation & Setup** – installing Tableau Desktop, configuring the workspace, and understanding the project folder structure.
+- **Connecting to Data Sources** – importing multiple CSV files, setting up joins and relationships, and verifying data quality checks.
+- **Creating Robust Data Models** – defining hierarchies, calculated fields, parameters, and leveraging level of detail expressions.
+- **Developing Insightful Visualizations** – designing charts with intent, applying color theory, and introducing advanced features such as quick table calculations.
+- **Crafting Professional Dashboards** – assembling the visualizations into an interactive sales command center with actions, filters, and storytelling techniques.
+
+The session culminated in the delivery of a polished sales dashboard that demonstrates how data visualization empowers business stakeholders to track KPIs, segment customers, and spot trends at a glance. The energy in the (virtual) room confirmed once again that learning by doing—and by teaching—creates the deepest understanding.
+
+![Tableau Workshop Journey](assets/tableau_workshop_agenda.svg)
+
+## Repository Contents
+
+| File | Description |
+| --- | --- |
+| `Sales_Dashboard.twb` | Tableau workbook used during the live session. Contains worksheets, dashboard layouts, and example calculations. |
+| `SalesDashboard.pbix` | Power BI version of the dashboard to showcase cross-platform storytelling. |
+| `assets/` | Hand-crafted visuals that summarize the experience for README and presentation purposes. |
+
+> **Note:** Sample data sources used during the workshop are not bundled in this repository. Replace the connections with your own data or point to the same file paths used in the session.
+
+## Getting Started with Tableau
+
+1. **Install Tableau Desktop** – Download a trial or use an academic license from [Tableau for Students](https://www.tableau.com/academic/students).
+2. **Open the Workbook** – Launch `Sales_Dashboard.twb`. Tableau will prompt you to locate the data sources. Select the CSV or Excel files you want to analyze.
+3. **Explore the Data Model** – Review the relationships pane to ensure joins and blends are configured correctly for your dataset.
+4. **Interact with the Dashboard** – Use filters, highlights, and actions to explore sales by time, geography, and customer segment.
+5. **Customize** – Adjust color palettes, swap out KPIs, or add new worksheets to tailor the dashboard to your business scenario.
+
+## Getting Started with Power BI
+
+1. **Install Power BI Desktop** from [Microsoft Download Center](https://www.microsoft.com/power-platform/products/power-bi/downloads).
+2. **Open `SalesDashboard.pbix`** and connect to your data sources when prompted.
+3. **Review the Model** using the model view to verify relationships, measures, and calculated columns.
+4. **Experiment with Interactions** by selecting visuals and observing how cross-filtering reveals insights.
+5. **Publish or Share** the report via Power BI Service to collaborate with teammates.
+
+## Recreating the Demo
+
+If you’d like to follow along from scratch:
+
+1. **Gather a Sales Dataset** – any dataset with orders, customers, and product categories will work.
+2. **Model the Data** – clean and normalize fields, then create calculated metrics such as total sales, average discount, and profit ratios.
+3. **Prototype Visuals** – start with line charts for time trends, bar charts for categorical comparisons, and maps for geographic analysis.
+4. **Assemble the Dashboard** – drag components onto the dashboard canvas, enable actions, and fine-tune the layout for readability.
+5. **Tell the Story** – pair key metrics with annotations and narrative text to guide stakeholders to the most important insights.
+
+## Reflection
+
+Delivering this workshop reinforced the idea that mentorship accelerates growth. The enthusiastic questions from the cohort sparked deeper exploration into best practices, performance tuning, and storytelling techniques—making the learning loop mutually rewarding.
+
+If you adapt the dashboard or run your own session, feel free to open an issue or share a link. I’d love to see how you extend the concepts! 🎉

--- a/assets/sales_dashboard_overview.svg
+++ b/assets/sales_dashboard_overview.svg
@@ -1,0 +1,48 @@
+<svg width="1200" height="720" viewBox="0 0 1200 720" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="720" fill="#f7f9fb" />
+  <rect x="40" y="30" width="1120" height="80" rx="12" fill="#0f4c81" />
+  <text x="600" y="85" text-anchor="middle" font-family="'Segoe UI', sans-serif" font-size="48" fill="#ffffff">Sales Dashboard Overview</text>
+
+  <rect x="40" y="140" width="720" height="260" rx="16" fill="#ffffff" stroke="#d8dee6" />
+  <text x="80" y="190" font-family="'Segoe UI', sans-serif" font-size="28" fill="#0f4c81">Monthly Revenue Trend</text>
+  <polyline fill="none" stroke="#1f77b4" stroke-width="6" points="120,340 200,320 280,300 360,260 440,240 520,210 600,190 680,180 760,170" />
+  <circle cx="120" cy="340" r="10" fill="#1f77b4" />
+  <circle cx="200" cy="320" r="10" fill="#1f77b4" />
+  <circle cx="280" cy="300" r="10" fill="#1f77b4" />
+  <circle cx="360" cy="260" r="10" fill="#1f77b4" />
+  <circle cx="440" cy="240" r="10" fill="#1f77b4" />
+  <circle cx="520" cy="210" r="10" fill="#1f77b4" />
+  <circle cx="600" cy="190" r="10" fill="#1f77b4" />
+  <circle cx="680" cy="180" r="10" fill="#1f77b4" />
+  <circle cx="760" cy="170" r="10" fill="#1f77b4" />
+  <text x="120" y="370" font-family="'Segoe UI', sans-serif" font-size="18" fill="#7a869a">Jan</text>
+  <text x="760" y="370" font-family="'Segoe UI', sans-serif" font-size="18" fill="#7a869a">Sep</text>
+
+  <rect x="800" y="140" width="360" height="260" rx="16" fill="#ffffff" stroke="#d8dee6" />
+  <text x="820" y="190" font-family="'Segoe UI', sans-serif" font-size="28" fill="#0f4c81">Category Mix</text>
+  <circle cx="980" cy="305" r="105" fill="#f1f5f9" stroke="#d8dee6" stroke-width="2" />
+  <path d="M980 305 L980 200 A105 105 0 0 1 1073 351 Z" fill="#ff7f0e" />
+  <path d="M980 305 L1073 351 A105 105 0 0 1 905 400 Z" fill="#2ca02c" />
+  <path d="M980 305 L905 400 A105 105 0 0 1 980 200 Z" fill="#9467bd" />
+  <text x="890" y="460" font-family="'Segoe UI', sans-serif" font-size="20" fill="#444">Electronics 45%</text>
+  <text x="890" y="490" font-family="'Segoe UI', sans-serif" font-size="20" fill="#444">Furniture 33%</text>
+  <text x="890" y="520" font-family="'Segoe UI', sans-serif" font-size="20" fill="#444">Office Supplies 22%</text>
+
+  <rect x="40" y="430" width="360" height="240" rx="16" fill="#ffffff" stroke="#d8dee6" />
+  <text x="60" y="480" font-family="'Segoe UI', sans-serif" font-size="28" fill="#0f4c81">Top Performing Regions</text>
+  <rect x="80" y="500" width="40" height="130" fill="#ff7f0e" />
+  <rect x="150" y="540" width="40" height="90" fill="#ff7f0e" />
+  <rect x="220" y="560" width="40" height="70" fill="#ff7f0e" />
+  <rect x="290" y="580" width="40" height="50" fill="#ff7f0e" />
+  <text x="80" y="650" font-family="'Segoe UI', sans-serif" font-size="18" fill="#7a869a">West</text>
+  <text x="150" y="650" font-family="'Segoe UI', sans-serif" font-size="18" fill="#7a869a">South</text>
+  <text x="220" y="650" font-family="'Segoe UI', sans-serif" font-size="18" fill="#7a869a">East</text>
+  <text x="290" y="650" font-family="'Segoe UI', sans-serif" font-size="18" fill="#7a869a">Midwest</text>
+
+  <rect x="440" y="430" width="720" height="240" rx="16" fill="#ffffff" stroke="#d8dee6" />
+  <text x="460" y="480" font-family="'Segoe UI', sans-serif" font-size="28" fill="#0f4c81">Workshop Highlights</text>
+  <text x="480" y="520" font-family="'Segoe UI', sans-serif" font-size="22" fill="#444">• Installation &amp; setup of Tableau</text>
+  <text x="480" y="555" font-family="'Segoe UI', sans-serif" font-size="22" fill="#444">• Connecting to multiple data sources</text>
+  <text x="480" y="590" font-family="'Segoe UI', sans-serif" font-size="22" fill="#444">• Building interactive dashboards</text>
+  <text x="480" y="625" font-family="'Segoe UI', sans-serif" font-size="22" fill="#444">• Storytelling with business insights</text>
+</svg>

--- a/assets/tableau_workshop_agenda.svg
+++ b/assets/tableau_workshop_agenda.svg
@@ -1,0 +1,40 @@
+<svg width="1200" height="600" viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0f4c81;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1c7fa6;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="600" fill="#f3f6fb" />
+  <rect x="80" y="60" width="1040" height="120" rx="20" fill="url(#grad)" />
+  <text x="600" y="135" text-anchor="middle" font-family="'Segoe UI', sans-serif" font-size="52" fill="#ffffff">Tableau Workshop Journey</text>
+
+  <g font-family="'Segoe UI', sans-serif" font-size="26" fill="#0f4c81">
+    <rect x="80" y="220" width="260" height="280" rx="18" fill="#ffffff" stroke="#d0d9e8" stroke-width="2" />
+    <text x="210" y="265" text-anchor="middle" font-size="30" font-weight="bold">Kick-off</text>
+    <text x="210" y="310" text-anchor="middle" fill="#4a6076">Install &amp; Setup</text>
+    <text x="210" y="350" text-anchor="middle" fill="#4a6076">Interface Tour</text>
+    <text x="210" y="390" text-anchor="middle" fill="#4a6076">Best Practices</text>
+
+    <rect x="470" y="220" width="260" height="280" rx="18" fill="#ffffff" stroke="#d0d9e8" stroke-width="2" />
+    <text x="600" y="265" text-anchor="middle" font-size="30" font-weight="bold">Build</text>
+    <text x="600" y="310" text-anchor="middle" fill="#4a6076">Connect to Data</text>
+    <text x="600" y="350" text-anchor="middle" fill="#4a6076">Model Relationships</text>
+    <text x="600" y="390" text-anchor="middle" fill="#4a6076">Visual Analytics</text>
+
+    <rect x="860" y="220" width="260" height="280" rx="18" fill="#ffffff" stroke="#d0d9e8" stroke-width="2" />
+    <text x="990" y="265" text-anchor="middle" font-size="30" font-weight="bold">Launch</text>
+    <text x="990" y="310" text-anchor="middle" fill="#4a6076">Dashboard Polish</text>
+    <text x="990" y="350" text-anchor="middle" fill="#4a6076">Storytelling</text>
+    <text x="990" y="390" text-anchor="middle" fill="#4a6076">Next Steps</text>
+  </g>
+
+  <polyline points="340,360 470,360" stroke="#1c7fa6" stroke-width="8" marker-end="url(#arrow)" fill="none" />
+  <polyline points="730,360 860,360" stroke="#1c7fa6" stroke-width="8" marker-end="url(#arrow)" fill="none" />
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1c7fa6" />
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- expand the README into a workshop companion guide with setup instructions and storytelling highlights
- add two SVG illustrations that summarize the sales dashboard layout and workshop journey

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0146ca1f0832d920863857222126b